### PR TITLE
Update development environment and add help functionality tests

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.18.3-otp-27
+erlang 27.1.1

--- a/test/tdig_test.exs
+++ b/test/tdig_test.exs
@@ -198,4 +198,28 @@ defmodule TdigTest do
       assert String.contains?(result, "2001:db8")
     end
   end
+
+  describe "help functionality" do
+    @tag :help
+    test "parse_args identifies help option with -h" do
+      result = Tdig.CLI.parse_args(["-h"])
+      assert result.help == true
+      assert result.exit_code == 0
+    end
+
+    @tag :help
+    test "parse_args identifies help option with --help" do
+      result = Tdig.CLI.parse_args(["--help"])
+      assert result.help == true
+      assert result.exit_code == 0
+    end
+
+    @tag :help
+    test "parse_args defaults to help when no name provided" do
+      result = Tdig.CLI.parse_args([])
+      # 引数なしの場合、nameは"."にデフォルト設定されるため、helpフラグは設定されない
+      assert result.name == "."
+      assert Map.get(result, :help) == nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Update development environment to use Elixir 1.18.3 with OTP 27
- Add comprehensive test coverage for help functionality (-h/--help options)
- Ensure compatibility with mix.exs Elixir ~> 1.17 requirement

## Changes
- **Environment**: Add \`.tool-versions\` with Elixir 1.18.3-otp-27 and Erlang 27.1.1
- **Tests**: Add help functionality test cases in \`test/tdig_test.exs\`
  - Test \`-h\` option parsing
  - Test \`--help\` option parsing  
  - Test default behavior when no arguments provided

## Test Plan
- [x] All existing tests continue to pass
- [x] New help functionality tests pass
- [x] Environment setup works with mise/asdf
- [x] Mix compilation succeeds with updated Elixir version

## Notes
During investigation, confirmed that \`-h\` option was already fully implemented in the codebase. This PR focuses on improving the development environment and test coverage.