### PR TITLE
Fix escript version spurious query (resolve #16)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,13 @@ defmodule Tdig.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     case Mix.env() do
-      :test -> [extra_applications: [:logger]]
-      _ -> [extra_applications: [:logger], mod: {Tdig.CLI, []}]
+      :prod ->
+        [
+          extra_applications: [:logger],
+          mod: {Tdig.CLI, []}
+        ]
+      _ ->
+        [extra_applications: [:logger]]
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes #16 - Escript version no longer shows spurious "Server Failure" query before actual query result.

## Root Cause

The issue was caused by the `mod: {Tdig.CLI, []}` setting in `mix.exs`, which triggered `Application.start` during escript execution. This caused `main/1` to be called **twice**:

1. **First call**: Via `Application.start` → `Bakeware.Script.start/2` → `Task.start_link` → `Tdig.CLI._main/0` → `Tdig.CLI.main([])` with empty args
2. **Second call**: Via escript runtime → `Tdig.CLI.main(argv)` with actual command-line arguments

The first call with empty args generated an invalid query for "." (root domain), resulting in the Server Failure response.

## Solution

Made the `mod` setting environment-dependent in `mix.exs`:

```elixir
def application do
  case Mix.env() do
    :prod ->
      [
        extra_applications: [:logger],
        mod: {Tdig.CLI, []}
      ]
    _ ->
      [extra_applications: [:logger]]
  end
end
```

### How it works:

- **escript mode** (`MIX_ENV=dev`): No `mod` setting → No `Application.start` → Single `main/1` execution via escript
- **Bakeware mode** (`MIX_ENV=prod`): Has `mod` setting → `Application.start` handles execution properly

## Testing

### Before fix:
```bash
$ ./tdig google.com A
;; ->>HEADER<<- opcode: QUERY, status: Server Failure, id: 33207
;; QUESTION SECTION:
;.			NIL	NIL
...

;; ->>HEADER<<- opcode: QUERY, status: No Error, id: 37952
;; QUESTION SECTION:
;google.com.			IN	A
...
```

### After fix:
```bash
# escript mode
$ mix escript.build && ./tdig google.com A
;; ->>HEADER<<- opcode: QUERY, status: No Error, id: 47848
;; QUESTION SECTION:
;google.com.			IN	A
...
✅ Single query, no spurious output

# Bakeware mode
$ MIX_ENV=prod mix release && _build/prod/rel/bakeware/tdig google.com A
;; ->>HEADER<<- opcode: QUERY, status: No Error, id: 970
;; QUESTION SECTION:
;google.com.			IN	A
...
✅ Works correctly
```

## Changes

- Modified `mix.exs` to conditionally set `mod` based on environment
- No changes to CLI logic required
- Both build modes work correctly

## Notes

- This issue only affected escript mode, not Bakeware mode
- Bakeware mode requires the `mod` setting for proper application startup
- The fix maintains compatibility with both build modes