### PR TITLE
ci: update reusable workflow references from @v1.x.x to @v1

### DIFF
--- a/.github/workflows/ai-reviewer.yml
+++ b/.github/workflows/ai-reviewer.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   ai-review:
-    uses: smkwlab/.github/.github/workflows/ai-reviewer.yml@v1.1.0
+    uses: smkwlab/.github/.github/workflows/ai-reviewer.yml@v1
     secrets: inherit

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   dependency-update:
-    uses: smkwlab/.github/.github/workflows/dependency-update.yml@v1.1.0
+    uses: smkwlab/.github/.github/workflows/dependency-update.yml@v1
     secrets: inherit

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -21,5 +21,5 @@ concurrency:
 
 jobs:
   ci:
-    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@v1.0.0
+    uses: smkwlab/.github/.github/workflows/elixir-ci.yml@v1
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   security:
-    uses: smkwlab/.github/.github/workflows/security.yml@v1.1.0
+    uses: smkwlab/.github/.github/workflows/security.yml@v1
     secrets: inherit


### PR DESCRIPTION
## Summary
Update all reusable workflow references to use major version tag `@v1` instead of specific versions.

## Benefits
- Bug fixes in smkwlab/.github are automatically applied
- No need to update each repository for patch/minor releases
- Follows GitHub Actions best practice