### PR TITLE
feat: add release workflow and dynamic version reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+# Release workflow for tdig
+#
+# Triggered on tag push matching X.Y.Z (no `v` prefix, consistent with
+# the pre-existing 0.2.0 tag). Builds a Bakeware standalone binary for
+# Linux x86_64 and macOS arm64, then attaches them to a GitHub Release.
+#
+# See Issue #49 for the design discussion and asset naming convention.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.asset_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_name: tdig-linux-x86_64
+            otp: '27.3.4.4'
+            elixir: '1.17.3'
+          - os: macos-latest
+            asset_name: tdig-macos-arm64
+            otp: '27.3.4.4'
+            elixir: '1.17.3'
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Erlang/Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          elixir-version: ${{ matrix.elixir }}
+
+      - name: Cache mix dependencies
+        uses: actions/cache@v4
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.exs') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Verify mix.exs version matches the tag
+        # Refuse to release if mix.exs version diverges from the pushed tag,
+        # which would leave `tdig --version` lying about the release.
+        run: |
+          MIX_VERSION=$(mix run --no-start -e 'IO.puts(Mix.Project.config()[:version])' | tail -n 1)
+          TAG_VERSION="${GITHUB_REF_NAME}"
+          if [ "${MIX_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::mix.exs version (${MIX_VERSION}) does not match the tag (${TAG_VERSION})"
+            exit 1
+          fi
+          echo "mix.exs version (${MIX_VERSION}) matches tag (${TAG_VERSION})"
+
+      - name: Build Bakeware release
+        env:
+          MIX_ENV: prod
+        run: mix release
+
+      - name: Rename binary for asset upload
+        run: |
+          cp _build/prod/rel/bakeware/tdig "${{ matrix.asset_name }}"
+          chmod +x "${{ matrix.asset_name }}"
+          ls -lh "${{ matrix.asset_name }}"
+
+      - name: Upload binary as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: ${{ matrix.asset_name }}
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect binaries into a flat directory
+        run: |
+          mkdir -p release
+          find artifacts -type f -exec cp {} release/ \;
+          ls -lh release/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "tdig ${GITHUB_REF_NAME}" \
+            --generate-notes \
+            release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,11 @@ name: Release
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      # Match numeric semver tags X.Y.Z. We use the extglob form
+      # `+([0-9])` ("one or more digits") to avoid any ambiguity around
+      # whether GitHub Actions' filter language treats `+` as a quantifier
+      # or as a literal character. See Issue #49 / PR #50 review thread.
+      - '+([0-9]).+([0-9]).+([0-9])'
 
 permissions:
   contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,12 +90,64 @@ mix deps.get && mix escript.build
 ```
 
 ### For End Users
-Download the standalone binary from releases:
+Download the standalone binary from releases. Pre-built binaries are published per platform:
+
+| Platform | Asset |
+|---|---|
+| Linux x86_64 | `tdig-linux-x86_64` |
+| macOS arm64 (Apple Silicon) | `tdig-macos-arm64` |
+
 ```bash
-curl -L -o tdig https://github.com/smkwlab/tdig/releases/latest/download/tdig
+# Auto-detect via uname
+OS=$(uname -s | tr '[:upper:]' '[:lower:]' | sed 's/darwin/macos/')
+ARCH=$(uname -m)
+curl -L -o tdig "https://github.com/smkwlab/tdig/releases/latest/download/tdig-${OS}-${ARCH}"
 chmod +x tdig
 ./tdig google.com A
 ```
+
+## Release Process
+
+Releases are produced by `.github/workflows/release.yml`, triggered automatically on tag push. There is **no scheduled/auto-bump trigger** — releasing is an explicit manual step performed by a maintainer.
+
+### Tag convention
+- Format: `X.Y.Z` (numeric semver, **no `v` prefix**, consistent with the pre-existing `0.2.0` tag)
+- The workflow's tag filter is `'[0-9]+.[0-9]+.[0-9]+'`. Anything else (e.g., `v1.0.0`, `0.3.0-rc1`, `latest`) is silently ignored.
+
+### Pre-release checklist
+1. The change you want to release is merged to `main`.
+2. `mix.exs` `:version` is bumped to the intended tag value (the workflow refuses to release if they diverge — this prevents `tdig --version` from lying about the published binary).
+3. `mix test` / `mix credo --strict` / `mix format --check-formatted` all pass on `main`.
+
+### Cutting a release
+
+```bash
+git checkout main
+git pull
+git tag 0.3.0           # must match mix.exs :version
+git push origin 0.3.0   # ← this triggers the release workflow
+```
+
+### What the workflow does
+1. **Build matrix** — runs in parallel on `ubuntu-latest` (Linux x86_64) and `macos-latest` (macOS arm64).
+2. **Version guard** — fails fast if `Mix.Project.config()[:version]` ≠ pushed tag name.
+3. **`MIX_ENV=prod mix release`** — produces the Bakeware binary at `_build/prod/rel/bakeware/tdig`.
+4. **Rename + upload artifact** — saves as `tdig-linux-x86_64` / `tdig-macos-arm64`.
+5. **Publish release** — collects both artifacts, then runs `gh release create <tag> --generate-notes <assets>`. Notes are auto-generated from PRs / commits since the previous tag.
+
+### Bumping the version
+
+```bash
+# 1. Edit mix.exs: version: "0.4.0"
+# 2. Commit (typically via PR) and merge to main
+# 3. git tag 0.4.0 && git push origin 0.4.0
+```
+
+If you tag without first bumping `mix.exs`, the workflow's version guard aborts the release. Re-tag after fixing.
+
+### Supported platforms
+
+Initially Linux x86_64 + macOS arm64. To add a new target (e.g., Linux arm64, macOS x86_64), append an entry to the `matrix.include` list in `release.yml` with the appropriate runner and `asset_name`. Bakeware embeds the Erlang runtime so cross-compilation is not supported — each target needs a native runner.
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Releases are produced by `.github/workflows/release.yml`, triggered automaticall
 
 ### Tag convention
 - Format: `X.Y.Z` (numeric semver, **no `v` prefix**, consistent with the pre-existing `0.2.0` tag)
-- The workflow's tag filter is `'[0-9]+.[0-9]+.[0-9]+'`. Anything else (e.g., `v1.0.0`, `0.3.0-rc1`, `latest`) is silently ignored.
+- The workflow's tag filter is `'+([0-9]).+([0-9]).+([0-9])'` (extglob form for "digits.digits.digits"). Anything else (e.g., `v1.0.0`, `0.3.0-rc1`, `latest`) is silently ignored.
 
 ### Pre-release checklist
 1. The change you want to release is merged to `main`.

--- a/lib/tdig/cli.ex
+++ b/lib/tdig/cli.ex
@@ -10,6 +10,16 @@ defmodule Tdig.CLI do
   Handles argument parsing, option processing, and main application entry point.
   """
 
+  # Read the project version from mix.exs at compile time so `tdig --version`
+  # never drifts from the canonical source (see Issue #49).
+  @version Mix.Project.config()[:version]
+
+  @doc """
+  Returns the application version as defined in `mix.exs`.
+  """
+  @spec version() :: String.t()
+  def version, do: @version
+
   # Entry point for both escript and Bakeware
   @impl Bakeware.Script
   @spec main([String.t()]) :: :ok
@@ -240,7 +250,7 @@ defmodule Tdig.CLI do
     arg
   end
 
-  def process(%{version: true}), do: IO.puts("tdig 0.3.1 (tenbin_dns 0.3.4)")
+  def process(%{version: true}), do: IO.puts("tdig #{version()}")
 
   def process(%{help: true, exit_code: exit_code}) do
     IO.puts("""

--- a/test/tdig_test.exs
+++ b/test/tdig_test.exs
@@ -249,7 +249,9 @@ defmodule TdigTest do
     test "version/0 is a non-empty semver-shaped string" do
       version = Tdig.CLI.version()
       assert is_binary(version)
-      assert String.match?(version, ~r/^\d+\.\d+\.\d+/), "expected semver, got #{inspect(version)}"
+
+      assert String.match?(version, ~r/^\d+\.\d+\.\d+/),
+             "expected semver, got #{inspect(version)}"
     end
   end
 

--- a/test/tdig_test.exs
+++ b/test/tdig_test.exs
@@ -240,6 +240,19 @@ defmodule TdigTest do
     end
   end
 
+  describe "version reporting (Issue #49)" do
+    test "version/0 returns the mix.exs project version" do
+      # Guards against stale hardcoded version strings drifting from mix.exs.
+      assert Tdig.CLI.version() == Mix.Project.config()[:version]
+    end
+
+    test "version/0 is a non-empty semver-shaped string" do
+      version = Tdig.CLI.version()
+      assert is_binary(version)
+      assert String.match?(version, ~r/^\d+\.\d+\.\d+/), "expected semver, got #{inspect(version)}"
+    end
+  end
+
   describe "help functionality" do
     @tag :help
     test "parse_args identifies help option with -h" do


### PR DESCRIPTION
## Summary

README で案内している GitHub Releases バイナリの提供を実体化します。並行する PR #48 (README 刷新) と組み合わせて「ドキュメントに書いてあるが実態がない」状態を解消します。

## 変更内容

### 1. \`.github/workflows/release.yml\` 新規追加

- **Trigger**: タグ \`X.Y.Z\` の push（v プレフィックス無し、既存 \`0.2.0\` と整合）
- **Matrix**:
  - \`ubuntu-latest\` → \`tdig-linux-x86_64\`
  - \`macos-latest\` (Apple Silicon) → \`tdig-macos-arm64\`
- **Steps**:
  1. setup-beam で OTP 27.3.4.4 / Elixir 1.17.3 を準備
  2. \`mix deps.get\`
  3. **バージョン整合性チェック**: \`mix.exs\` の version とタグ名が一致しなければ即失敗（\`tdig --version\` がリリース内容と乖離するのを防ぐ）
  4. \`MIX_ENV=prod mix release\` で Bakeware バイナリ生成
  5. プラットフォーム別名にリネーム、workflow artifact として upload
- **Release job**: 全 matrix 完了後、各 artifact を集約して \`gh release create\` で公開

### 2. \`Tdig.CLI\` のバージョン動的化

- 旧: \`process(%{version: true}), do: IO.puts(\"tdig 0.3.1 (tenbin_dns 0.3.4)\")\` — ハードコード、mix.exs \`0.3.0\` と乖離
- 新: \`@version Mix.Project.config()[:version]\` をコンパイル時に注入、\`Tdig.CLI.version/0\` で公開
- TDD で 2 件のテスト追加（mix.exs と一致 / semver 形式）

### 3. README ダウンロード手順（PR #48 で更新）

本PRと並行する PR #48 のブランチで、ダウンロード手順を新 asset 名 (\`tdig-linux-x86_64\` / \`tdig-macos-arm64\`) とプラットフォーム別 curl 例 + uname ベース auto-detect snippet に更新済み。両 PR の merge 順は問いません。

## マージ後の手順（リリース実体化）

\`\`\`bash
git checkout main && git pull
git tag 0.3.0
git push origin 0.3.0
\`\`\`

これで release workflow が起動し、両プラットフォーム分のバイナリが添付された GitHub Release \`0.3.0\` が作成されます。

## 命名規約

| 項目 | 規約 |
|---|---|
| タグ | \`X.Y.Z\`（v プレフィックス無し、既存 \`0.2.0\` 踏襲） |
| Asset | \`tdig-{os}-{arch}\` |
| 初回リリース対象 | \`0.3.0\`（mix.exs の version） |

## Test plan
- [x] \`mix test\` 38 件 / 0 failures（新規 TDD テスト 2 件追加）
- [x] \`mix credo --strict\` 0 issues
- [x] \`mix format --check-formatted\` 通過
- [x] \`./tdig --version\` がローカルで \`tdig 0.3.0\` を返すこと確認
- [ ] Workflow の実走確認は merge 後の初回タグ push で行う

## 関連
- PR #48 (README 刷新) と組み合わせで完結。README のダウンロード URL は両 PR merge 後に最終形になる
- 既存タグ \`0.2.0\` は Release 化せずそのまま履歴として残置

resolve #49