### PR TITLE
fix(release): revert tag filter to documented pattern syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,15 @@ name: Release
 on:
   push:
     tags:
-      # Match numeric semver tags X.Y.Z. We use the extglob form
-      # `+([0-9])` ("one or more digits") to avoid any ambiguity around
-      # whether GitHub Actions' filter language treats `+` as a quantifier
-      # or as a literal character. See Issue #49 / PR #50 review thread.
-      - '+([0-9]).+([0-9]).+([0-9])'
+      # Match numeric semver tags X.Y.Z. GitHub Actions tag filters
+      # support `+` as "one or more of the preceding character" (see the
+      # cheat sheet at
+      # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      # which shows `v[12].[0-9]+.[0-9]+` matching `v1.0.2`). The extglob
+      # form `+([0-9])` is NOT supported here and silently fails to
+      # match real tags (verified empirically: tag `0.3.0` did not
+      # trigger this workflow when the pattern was extglob).
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Releases are produced by `.github/workflows/release.yml`, triggered automaticall
 
 ### Tag convention
 - Format: `X.Y.Z` (numeric semver, **no `v` prefix**, consistent with the pre-existing `0.2.0` tag)
-- The workflow's tag filter is `'+([0-9]).+([0-9]).+([0-9])'` (extglob form for "digits.digits.digits"). Anything else (e.g., `v1.0.0`, `0.3.0-rc1`, `latest`) is silently ignored.
+- The workflow's tag filter is `'[0-9]+.[0-9]+.[0-9]+'` (`+` as the "one or more of preceding" quantifier per the GitHub Actions filter cheat sheet, with literal `.` as separator). Anything else (e.g., `v1.0.0`, `0.3.0-rc1`, `latest`) is silently ignored.
 
 ### Pre-release checklist
 1. The change you want to release is merged to `main`.


### PR DESCRIPTION
## Summary

PR #50 で導入した release workflow のタグフィルタを、Copilot 指摘を受けて extglob 形式 `'+([0-9]).+([0-9]).+([0-9])'` に変更しました。しかし**この変更は誤り**で、`0.3.0` タグを push しても workflow が起動しないことを実証しました。

## 経緯

1. PR #50 元のパターン: `'[0-9]+.[0-9]+.[0-9]+'`
2. Copilot レビュー: 「`+` is treated literally, so `0.3.0` will not trigger」と警告
3. 安全側に倒して extglob `'+([0-9]).+([0-9]).+([0-9])'` に変更
4. PR #48 / PR #50 merge 後、`git tag 0.3.0 && git push origin 0.3.0` 実行
5. **Release workflow が起動せず**、`gh run list` でも tag-event の run が皆無

## 根拠

[GitHub Actions filter pattern cheat sheet](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) の公式例:

> `'v[12].[0-9]+.[0-9]+'` Matches refs that match the regular expression. Matches `v1.0.2` and `v2.4.5`.

`+` は明確に "one or more of the preceding character" として量指定子サポート。extglob 形式 `+(...)` は filter language にドキュメント記載なく、サイレントにマッチ失敗していました。

つまり **Copilot 指摘の方が誤り**、PR #50 当初のパターン `'[0-9]+.[0-9]+.[0-9]+'` が正解でした。

## 変更内容

- `.github/workflows/release.yml`: タグフィルタを `'[0-9]+.[0-9]+.[0-9]+'` に revert、教訓を含むコメント追加
- `CLAUDE.md`: Release Process セクションのパターン記述を整合

## マージ後の手順

```bash
git checkout main && git pull
git tag 0.3.0
git push origin 0.3.0
```

今度こそ workflow が起動するはずです。

## Test plan
- [x] ドキュメント上は GitHub Actions 公式 cheat sheet と整合
- [ ] 実走確認: merge 後にタグ push して workflow が triggered になることを観測