### PR TITLE
ci: bump AI code review model to claude-opus-4-8

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -22,6 +22,6 @@ jobs:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
     with:
-      model_code: claude-sonnet-4-6
+      model_code: claude-opus-4-8
       review_mode: CODE
       language: Japanese


### PR DESCRIPTION
## Summary

AI コードレビューワークフロー (`ai-code-review.yml`) が使用するモデルを `claude-sonnet-4-6` から `claude-opus-4-8` に更新します。

## Changes

- `model_code: claude-sonnet-4-6` → `model_code: claude-opus-4-8`

## Notes

- ワークフロー設定のみの変更で、Elixir コードへの変更はありません。
- `review_mode: CODE` / `language: Japanese` の設定は変更なし。