### PR TITLE
docs: add Mermaid pipeline architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,32 @@ If you already have BIND's `dig`, you don't need `tdig`. It's useful when:
 - **escript / source build**: Elixir 1.17 or later, Erlang/OTP 27 or later. CI exercises the matrix Elixir 1.17.3 / OTP 27.3.4.4 (LTS) and Elixir 1.19.5 / OTP 28.5 (latest) via the shared reusable workflow `smkwlab/.github/.github/workflows/elixir-ci.yml@v1`.
 - **Git** is needed for `mix deps.get` because `tenbin_dns` is fetched from a git tag
 
+## Architecture
+
+`tdig` is a thin query pipeline: command-line arguments are parsed into a single options map, that map drives DNS resolution, and the wire response is parsed and printed in `dig`-style sections. The same entry point (`Tdig.CLI.main/1`) backs both the escript and Bakeware builds.
+
+```mermaid
+graph LR
+  argv["argv<br/>(command-line args)"] --> cli["Tdig.CLI<br/>(parse_args: options + positional + EDNS/PTR)"]
+  cli --> resolve["Tdig.resolve<br/>(orchestration)"]
+  resolve --> build["DNSpacket.create<br/>(build query via tenbin_dns)"]
+  build --> send["send_server<br/>(UDP / TCP send + recv)"]
+  send --> parse["DNSpacket.parse<br/>(decode response via tenbin_dns)"]
+  parse --> disp["disp_response<br/>(dig-style sections + summary)"]
+
+  send -. "TC flag: retry over TCP" .-> resolve
+  read["--read file"] -. "skip network" .-> parse
+```
+
+Legend and notes:
+
+- **Solid arrows** trace the main request/response data flow; **dotted arrows** are conditional side paths.
+- `Tdig.CLI.parse_args/1` turns `argv` into an options map: it parses switches and positional `[@server] host [type] [class]` arguments, applies defaults (server `8.8.8.8`, type `A`, class `IN`, port `53`), auto-selects IPv4/IPv6 from the server address, and handles EDNS0 and `-x` reverse-lookup rewriting. `process/1` short-circuits `--version` / `--help` before reaching resolution.
+- `Tdig.resolve/1` builds the query with `tenbin_dns` (`DNSpacket.create/1`), sends it over UDP or TCP via the `socket` library, then parses and renders the reply (`DNSpacket.parse/1` → `disp_response/3`).
+- **TC retry** (dotted): a truncated UDP response re-enters `resolve/1` in TCP mode unless `--ignore` is set.
+- **`--read`** (dotted): a saved packet file is fed straight into the parse/display stage, bypassing the network entirely. `--write` / `--write-request` (not shown) persist the raw answer / query packets along the main path.
+- The two build modes (escript vs. Bakeware) share this exact pipeline; they differ only in packaging, not in query handling.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ graph LR
   send --> parse["DNSpacket.parse<br/>(decode response via tenbin_dns)"]
   parse --> disp["disp_response<br/>(dig-style sections + summary)"]
 
-  send -. "TC flag: retry over TCP" .-> resolve
+  disp -. "TC flag: retry over TCP" .-> resolve
   read["--read file"] -. "skip network" .-> parse
 ```
 
@@ -239,7 +239,7 @@ Legend and notes:
 - **Solid arrows** trace the main request/response data flow; **dotted arrows** are conditional side paths.
 - `Tdig.CLI.parse_args/1` turns `argv` into an options map: it parses switches and positional `[@server] host [type] [class]` arguments, applies defaults (server `8.8.8.8`, type `A`, class `IN`, port `53`), auto-selects IPv4/IPv6 from the server address, and handles EDNS0 and `-x` reverse-lookup rewriting. `process/1` short-circuits `--version` / `--help` before reaching resolution.
 - `Tdig.resolve/1` builds the query with `tenbin_dns` (`DNSpacket.create/1`), sends it over UDP or TCP via the `socket` library, then parses and renders the reply (`DNSpacket.parse/1` → `disp_response/3`).
-- **TC retry** (dotted): a truncated UDP response re-enters `resolve/1` in TCP mode unless `--ignore` is set.
+- **TC retry** (dotted): the truncation flag is inspected only after the response is parsed — `disp_response/3` calls `check_tc_flag/2`, which re-enters `resolve/1` in TCP mode unless `--ignore` is set.
 - **`--read`** (dotted): a saved packet file is fed straight into the parse/display stage, bypassing the network entirely. `--write` / `--write-request` (not shown) persist the raw answer / query packets along the main path.
 - The two build modes (escript vs. Bakeware) share this exact pipeline; they differ only in packaging, not in query handling.
 


### PR DESCRIPTION
## 概要

エコシステム横断ドキュメント整備 TODO #5（アーキテクチャ図の Mermaid 化と一貫適用）の一環として、tdig README に存在しなかったアーキテクチャ図を新規追加します。tdig はクエリ処理の pipeline 構造なので `graph LR` で図示しました（参照実装は tenbin_cache PR #106 のスタイル方針に準拠）。

## lib/ で確認した実際の処理フロー

README / CLAUDE.md の記述を鵜呑みにせず、`lib/tdig/cli.ex` / `lib/tdig.ex` の実コードと照合して作成しました。

- エントリポイント `Tdig.CLI.main/1`（escript / Bakeware 共通）→ `run/1`
- `run/1`: `parse_args/1` → `process/1`
- `parse_args/1`: `OptionParser.parse` → `parse_switches` → `parse_argv`（`[@server] host [type] [class]` の位置引数解析）→ `merge_switches_and_argv` → 既定値適用（server `8.8.8.8` / type `A` / class `IN` / port `53`）→ `check_server_address`（アドレスから v4/v6 自動選択）→ `check_edns`（EDNS0 / ECS）→ `check_args`（`-x` 逆引き書き換え・help 判定）
- `process/1`: `--version` / `--help` を short-circuit し、それ以外は `Tdig.resolve/1` へ
- `Tdig.resolve/1`: `get_response` → `write_file`（応答保存）→ `disp_response`
  - `get_response`: `--read` 指定時はパケットファイル読込、通常時は `%DNSpacket{}` 構築 → `DNSpacket.create`（tenbin_dns）→ `write_file`（クエリ保存）→ `send_server`
  - `send_server`: `socket` ライブラリ経由で UDP / TCP 送受信
  - `disp_response`: `DNSpacket.parse` → `check_tc_flag`（TC フラグ時 TCP リトライ、`--ignore` で抑止）→ header / EDNS / question / answer 各セクション表示 → `disp_tailer`

## 追加した Mermaid

`## Architecture` セクションを `## Requirements` と `## Development` の間に新設し、以下を追加しました。

```mermaid
graph LR
  argv["argv<br/>(command-line args)"] --> cli["Tdig.CLI<br/>(parse_args: options + positional + EDNS/PTR)"]
  cli --> resolve["Tdig.resolve<br/>(orchestration)"]
  resolve --> build["DNSpacket.create<br/>(build query via tenbin_dns)"]
  build --> send["send_server<br/>(UDP / TCP send + recv)"]
  send --> parse["DNSpacket.parse<br/>(decode response via tenbin_dns)"]
  parse --> disp["disp_response<br/>(dig-style sections + summary)"]

  disp -. "TC flag: retry over TCP" .-> resolve
  read["--read file"] -. "skip network" .-> parse
```

図の直後に凡例・補足を prose で併記しています。

> 注: 当初は TC リトライの点線を `send` 起点で描いていましたが、レビュー指摘を受けて実コード（`disp_response/3` 内で `DNSpacket.parse` 後に `check_tc_flag/2` → `resolve/1` 再入）に合わせ `disp` 起点へ修正しました（この description の図も修正済み）。

## スタイル方針

- pipeline 系なので `graph LR`
- 実線（`-->`）= 主要なデータフロー、点線（`-. label .->`）= 補助的関係（TC リトライ・`--read` バイパス）
- `classDef` 等の装飾は不使用（GitHub の Mermaid 描画懸念の教訓）
- ノードラベルは `"名前<br/>(役割)"` 形式
- ビルドモード（escript / Bakeware）は主眼ではなく、両モードが同一 pipeline を共有する旨を補足のみで言及

docs のみの変更です。`mix format --check-formatted` は green（Elixir コードは未変更）。