### PR TITLE
Escape control bytes in DNS response output (terminal injection) (#58)

### DIFF
--- a/lib/tdig.ex
+++ b/lib/tdig.ex
@@ -212,8 +212,8 @@ defmodule Tdig do
     :inet.ntoa(subnet) |> to_string()
   end
 
-  defp format_ecs_subnet(subnet) when is_binary(subnet), do: subnet
-  defp format_ecs_subnet(subnet) when is_list(subnet), do: to_string(subnet)
+  defp format_ecs_subnet(subnet) when is_binary(subnet), do: escape(subnet)
+  defp format_ecs_subnet(subnet) when is_list(subnet), do: escape(to_string(subnet))
   defp format_ecs_subnet(_), do: "invalid"
 
   def disp_question(p) do
@@ -228,7 +228,7 @@ defmodule Tdig do
   end
 
   def question_item_to_string(q) do
-    ";#{q.qname}			#{q.qclass |> a2s}	#{q.qtype |> a2s}"
+    ";#{escape(q.qname)}			#{q.qclass |> a2s}	#{q.qtype |> a2s}"
   end
 
   def disp_answer(p, part, is_sort) do
@@ -258,24 +258,43 @@ defmodule Tdig do
 
   def answer_item_to_string(a) do
     """
-    #{a.name}		#{a.ttl}	#{a.class |> a2s}	#{a.type |> a2s}	#{a.rdata |> rdata_to_string(a.type)}
+    #{escape(a.name)}		#{a.ttl}	#{a.class |> a2s}	#{a.type |> a2s}	#{a.rdata |> rdata_to_string(a.type)}
     """
   end
 
   def rdata_to_string(rdata, :a), do: :inet.ntoa(rdata.addr)
   def rdata_to_string(rdata, :aaaa), do: :inet.ntoa(rdata.addr)
-  def rdata_to_string(rdata, :ns), do: rdata.name
-  def rdata_to_string(rdata, :ptr), do: rdata.name
-  def rdata_to_string(rdata, :cname), do: rdata.name
-  def rdata_to_string(rdata, :txt), do: rdata.txt
-  def rdata_to_string(rdata, :mx), do: "#{rdata.preference} #{rdata.name}"
-  def rdata_to_string(rdata, :caa), do: "#{rdata.flag} #{rdata.tag} #{rdata.value}"
+  def rdata_to_string(rdata, :ns), do: escape(rdata.name)
+  def rdata_to_string(rdata, :ptr), do: escape(rdata.name)
+  def rdata_to_string(rdata, :cname), do: escape(rdata.name)
+  def rdata_to_string(rdata, :txt), do: escape(rdata.txt)
+  def rdata_to_string(rdata, :mx), do: "#{rdata.preference} #{escape(rdata.name)}"
+
+  def rdata_to_string(rdata, :caa),
+    do: "#{rdata.flag} #{escape(rdata.tag)} #{escape(rdata.value)}"
 
   def rdata_to_string(rdata, :soa),
     do:
-      "#{rdata.mname} #{rdata.rname} #{rdata.serial} #{rdata.refresh} #{rdata.retry} #{rdata.expire} #{rdata.minimum}"
+      "#{escape(rdata.mname)} #{escape(rdata.rname)} #{rdata.serial} #{rdata.refresh} #{rdata.retry} #{rdata.expire} #{rdata.minimum}"
 
   def rdata_to_string(rdata, _), do: inspect(rdata)
+
+  @doc """
+  Escape control/non-printable bytes so an untrusted DNS response field cannot
+  inject ANSI/OSC terminal escape sequences when written to a TTY.
+
+  Printable ASCII passes through; backslash becomes `\\\\` and every other byte
+  (C0/C1 controls, DEL, high bytes) becomes `\\DDD` (3-digit decimal), matching
+  `dig`'s presentation of non-printable octets.
+  """
+  @spec escape(binary()) :: binary()
+  def escape(string) when is_binary(string) do
+    for <<byte <- string>>, into: "", do: escape_byte(byte)
+  end
+
+  defp escape_byte(?\\), do: "\\\\"
+  defp escape_byte(byte) when byte in 0x20..0x7E, do: <<byte>>
+  defp escape_byte(byte), do: "\\" <> String.pad_leading(Integer.to_string(byte), 3, "0")
 
   def disp_tailer(server, port, size, time) do
     # Get system local time using NaiveDateTime (OS-independent, cleaner)

--- a/test/tdig_test.exs
+++ b/test/tdig_test.exs
@@ -279,4 +279,54 @@ defmodule TdigTest do
       assert Map.get(result, :help) == nil
     end
   end
+
+  describe "terminal output escaping (G)" do
+    test "escape/1 passes printable ASCII through unchanged" do
+      assert Tdig.escape("example.com.") == "example.com."
+      assert Tdig.escape("a-b_c 123!") == "a-b_c 123!"
+    end
+
+    test "escape/1 renders control and non-printable bytes as \\DDD" do
+      # ESC (0x1B) — the byte that starts ANSI/OSC sequences — must not pass through.
+      assert Tdig.escape(<<0x1B, "[31mX">>) == "\\027[31mX"
+      assert Tdig.escape(<<0, 9, 10, 13>>) == "\\000\\009\\010\\013"
+      assert Tdig.escape(<<0x7F>>) == "\\127"
+      # high byte
+      assert Tdig.escape(<<0xFF>>) == "\\255"
+    end
+
+    test "escape/1 escapes backslash so the encoding is unambiguous" do
+      assert Tdig.escape("a\\b") == "a\\\\b"
+    end
+
+    test "rdata_to_string escapes untrusted TXT and name bytes" do
+      assert Tdig.rdata_to_string(%{txt: <<"hi", 0x1B, "!">>}, :txt) == "hi\\027!"
+
+      assert Tdig.rdata_to_string(%{name: <<"ns", 0x1B, ".example.">>}, :cname) ==
+               "ns\\027.example."
+
+      assert Tdig.rdata_to_string(%{flag: 0, tag: "issue", value: <<0x1B, "ca">>}, :caa) ==
+               "0 issue \\027ca"
+    end
+
+    test "answer_item_to_string escapes the owner name" do
+      line =
+        Tdig.answer_item_to_string(%{
+          name: <<"host", 0x1B, ".example.">>,
+          ttl: 60,
+          class: :in,
+          type: :a,
+          rdata: %{addr: {192, 0, 2, 1}}
+        })
+
+      refute line =~ <<0x1B>>
+      assert line =~ "host\\027.example."
+    end
+
+    test "question_item_to_string escapes the qname" do
+      line = Tdig.question_item_to_string(%{qname: <<"q", 0x1B, ".">>, qclass: :in, qtype: :a})
+      refute line =~ <<0x1B>>
+      assert line =~ "q\\027."
+    end
+  end
 end


### PR DESCRIPTION
Fixes #58.

## Problem

tdig printed DNS response fields to the terminal without escaping control/non-printable bytes, so a malicious DNS server (or a crafted packet fed via `--read`) could embed **ANSI/OSC escape sequences** in a response and spoof the terminal (rewrite displayed lines, set the window title, etc.). `dig` escapes non-printable octets as `\DDD`; tdig did not.

Affected output paths (`lib/tdig.ex`): the QUESTION `qname`, the record owner `name`, `rdata_to_string/2` for NS/PTR/CNAME/MX/SOA names, TXT text, and CAA tag/value, and the binary/list branches of `format_ecs_subnet/1`.

## Fix

Add `escape/1`: printable ASCII passes through, backslash becomes `\\`, and every other byte (C0/C1 controls incl. ESC, DEL, high bytes) becomes `\DDD` (decimal), matching dig's presentation. Apply it to the untrusted string fields above. Numeric fields (`:inet.ntoa`, TTLs) and the `inspect/1` catch-all were already safe.

## Verification

New tests: `escape/1` (printable passthrough, ESC/control/DEL/high → `\DDD`, backslash → `\\`) and that `rdata_to_string`, `answer_item_to_string`, and `question_item_to_string` escape untrusted bytes. Verified end to end that a TXT record carrying an OSC title-set + ANSI escape renders as `\027]0;...\007\027[...` with **no raw ESC/BEL** reaching the output. Full suite green (44 tests), `mix credo --strict` clean.

Found during an ecosystem security review (theme G).

🤖 Generated with [Claude Code](https://claude.com/claude-code)