### PR TITLE
Align tenbin_dns to 0.7.1 to match the servers (E-1)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,9 @@ defmodule Tdig.MixProject do
   defp deps do
     [
       {:bakeware, "~> 0.2.3", runtime: false},
-      {:tenbin_dns, git: "https://github.com/smkwlab/tenbin_dns.git", tag: "0.7.0"},
+      # Immutable release tag, aligned with the servers (tenbin_ex / tenbin_cache)
+      # to avoid version drift (supply-chain hardening, smkwlab/.github#69 E-1).
+      {:tenbin_dns, git: "https://github.com/smkwlab/tenbin_dns.git", tag: "0.7.1"},
       {:socket, "~> 0.3.13"},
       {:zoneinfo, "~> 0.1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -8,6 +8,6 @@
   "file_system": {:hex, :file_system, "1.1.1", "31864f4685b0148f25bd3fbef2b1228457c0c89024ad67f7a81a3ffbc0bbad3a", [:mix], [], "hexpm", "7a15ff97dfe526aeefb090a7a9d3d03aa907e100e262a0f8f7746b78f8f87a5d"},
   "jason": {:hex, :jason, "1.4.5", "2e3a008590b0b8d7388c20293e9dcc9cf3e5d642fd2a114e4cbbb52e595d940a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0 or ~> 3.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b0c823996102bcd0239b3c2444eb00409b72f6a140c1950bc8b457d836b30684"},
   "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm", "f82ea9833ef49dde272e6568ab8aac657a636acb4cf44a7de8a935acb8957c2e"},
-  "tenbin_dns": {:git, "https://github.com/smkwlab/tenbin_dns.git", "93c20489b1cf9a05548b9403b7fc3fc60b51912f", [tag: "0.7.0"]},
+  "tenbin_dns": {:git, "https://github.com/smkwlab/tenbin_dns.git", "3a9b12d5c597cbf22cfff43fb5948f84b0aedf20", [tag: "0.7.1"]},
   "zoneinfo": {:hex, :zoneinfo, "0.1.8", "add41f44e6f19d4d16d9eebe3261d6307c58bdbe7cc61ffb7b18cad346b0467f", [:mix], [], "hexpm", "3999755971bbf85f0c8c75a724be560199bb63406660585849f0eb680e2333f7"},
 }


### PR DESCRIPTION
## Summary

Supply-chain hardening — **E-1** of the ecosystem security review (smkwlab/.github#69).

tdig pinned `tenbin_dns` at tag `0.7.0` while `tenbin_ex` / `tenbin_cache` use `0.7.1` — version drift across the ecosystem. Align tdig to the same immutable release tag `0.7.1`, which also carries the `tenbin_dns` parser hardening (#120).

`tenbin_dns` `0.7.0` → `0.7.1` (SHA `3a9b12d5…`, identical to the servers).

## Verification

- `mix compile` clean
- **44 tests, 0 failures**
- End-to-end escript query parses a live response correctly:
  ```
  $ ./tdig example.com A @8.8.8.8
  ;; ANSWER SECTION:
  example.com.  300  IN  A  104.20.23.154
  example.com.  300  IN  A  172.66.147.243
  ```

Refs smkwlab/.github#69 (E-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)