### PR TITLE
Publish SHA256SUMS for release binaries (E-5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,16 @@ jobs:
           find artifacts -type f -exec cp {} release/ \;
           ls -lh release/
 
+      - name: Generate SHA256SUMS
+        # Publish a checksum manifest so downloads can be verified
+        # (curl | chmod | run otherwise trusts the transport blindly).
+        # `tdig-*` deliberately excludes the SHA256SUMS file itself.
+        run: |
+          cd release
+          sha256sum tdig-* | tee SHA256SUMS
+          # Sanity check the manifest round-trips before publishing.
+          sha256sum -c SHA256SUMS
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,16 @@ jobs:
         # (curl | chmod | run otherwise trusts the transport blindly).
         # `tdig-*` deliberately excludes the SHA256SUMS file itself.
         run: |
+          shopt -s nullglob
           cd release
-          sha256sum tdig-* | tee SHA256SUMS
+          bins=(tdig-*)
+          # Refuse to publish an unverifiable release if no binaries were
+          # collected (fail loudly instead of a bare literal-glob error).
+          if [ "${#bins[@]}" -eq 0 ]; then
+            echo "::error::no tdig-* binaries found in release/; refusing to publish"
+            exit 1
+          fi
+          sha256sum "${bins[@]}" | tee SHA256SUMS
           # Sanity check the manifest round-trips before publishing.
           sha256sum -c SHA256SUMS
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,15 @@ chmod +x tdig
 #### Verifying the download
 
 Each release also publishes a `SHA256SUMS` manifest. Verify the binary's
-integrity before running it:
+integrity before running it. `sha256sum` matches entries by filename, so keep
+the binary under its release asset name for the check (e.g. download with
+`-o tdig-linux-x86_64`, verify, then rename/`chmod`). If no manifest entry
+matches any local file, `sha256sum` exits non-zero with `no file was verified`
+rather than silently passing.
 
 ```bash
-# Download the checksum manifest alongside the binary
+# Download the binary under its asset name and the manifest alongside it
+curl -L -o tdig-linux-x86_64 https://github.com/smkwlab/tdig/releases/latest/download/tdig-linux-x86_64
 curl -L -o SHA256SUMS https://github.com/smkwlab/tdig/releases/latest/download/SHA256SUMS
 
 # Check the binary you downloaded (ignores the other platform's entry)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ chmod +x tdig
 ./tdig example.com A
 ```
 
+#### Verifying the download
+
+Each release also publishes a `SHA256SUMS` manifest. Verify the binary's
+integrity before running it:
+
+```bash
+# Download the checksum manifest alongside the binary
+curl -L -o SHA256SUMS https://github.com/smkwlab/tdig/releases/latest/download/SHA256SUMS
+
+# Check the binary you downloaded (ignores the other platform's entry)
+sha256sum --ignore-missing -c SHA256SUMS
+# tdig-linux-x86_64: OK
+```
+
+On macOS, use `shasum -a 256 --ignore-missing -c SHA256SUMS`.
+
 ### For Elixir developers — escript
 
 If you already have Elixir installed and want a fast iterative build:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,14 @@ sha256sum --ignore-missing -c SHA256SUMS
 # tdig-linux-x86_64: OK
 ```
 
-On macOS, use `shasum -a 256 --ignore-missing -c SHA256SUMS`.
+On macOS, `shasum` ships with the system but its Perl build has no
+`--ignore-missing`, so verify just the relevant line (portable — works on
+Linux too):
+
+```bash
+grep tdig-macos-arm64 SHA256SUMS | shasum -a 256 -c -
+# tdig-macos-arm64: OK
+```
 
 ### For Elixir developers — escript
 


### PR DESCRIPTION
## Summary

Supply-chain hardening — **E-5** of the ecosystem security review (smkwlab/.github#69).

The Bakeware binaries (`tdig-linux-x86_64` / `tdig-macos-arm64`) were attached to each GitHub Release with **no checksum or signature**, and the README installs them via `curl | chmod | run` — trusting the transport blindly.

## Changes

- **`release.yml`** — a new *Generate SHA256SUMS* step in the `release` job runs `sha256sum tdig-*` over the collected binaries (the `tdig-*` glob deliberately excludes the manifest itself) and round-trips it with `sha256sum -c` before publishing. The file lands in `release/`, so the existing `gh release create … release/*` glob uploads it as a release asset.
- **README** — a *Verifying the download* section: `sha256sum --ignore-missing -c SHA256SUMS` (plus the macOS `shasum -a 256` form).

## Verification

- Command logic validated locally: the manifest lists only the two binaries by basename, round-trips with `-c`, and `--ignore-missing -c` verifies a single downloaded binary against the full manifest (`tdig-linux-x86_64: OK`).
- `actionlint` passes on `release.yml`.
- ⚠️ **Full end-to-end confirmation needs a real tagged release run** — the release workflow only fires on a `X.Y.Z` tag push, which is a maintainer action. Per the ecosystem rule "verify CI/deploy changes on a real green run," this item should be confirmed on the next release (or a throwaway test tag) before ticking it off in #69.

## Follow-up (not in this PR)

Signing (**cosign keyless** via GitHub OIDC — no key management, or **minisign**) can layer authenticity on top of these integrity checksums. Deliberately deferred: it adds an external action + `id-token: write` and can't be verified without a real release, so it's best validated on a test release rather than shipped blind into the release path.

Refs smkwlab/.github#69 (E-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)