### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Tdig.MixProject do
   def project do
     [
       app: :tdig,
-      version: "0.3.0",
+      version: "0.4.0",
       name: "Tdig",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Prepare the **0.4.0** release. `mix.exs` `:version` `0.3.0` → `0.4.0`.

The release workflow's version guard aborts unless `mix.exs` `:version` equals the pushed tag, so this bump must land before tagging `0.4.0`.

## What 0.4.0 ships (unreleased since 0.3.0)

- **Security**: escape control bytes in DNS response output — terminal injection (#59)
- **E-1** (smkwlab/.github#69): align `tenbin_dns` to `0.7.1` to match the servers (#60)
- **E-5** (smkwlab/.github#69): publish `SHA256SUMS` for release binaries (#61)
- docs: Mermaid pipeline diagram (#57); Elixir 1.20.1 compatibility (#56)

## Verification

- `Mix.Project.config()[:version]` → `0.4.0` (the exact call the workflow's guard reads)
- `mix test` → 44 tests, 0 failures

After merge: `git tag 0.4.0 && git push origin 0.4.0` triggers `release.yml`, which is also the end-to-end verification of the E-5 `SHA256SUMS` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)