### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep SHA-pinned third-party GitHub Actions up to date (Renovate here is
+  # mix-only, so it does not manage Actions). Reusable workflows stay on @v1.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,16 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Erlang/Elixir
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
 
       - name: Cache mix dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.exs') }}
@@ -85,7 +85,7 @@ jobs:
           ls -lh "${{ matrix.asset_name }}"
 
       - name: Upload binary as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ matrix.asset_name }}
@@ -99,10 +99,10 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
 


### PR DESCRIPTION
## What

Pin third-party GitHub Actions in `.github/workflows/release.yml` to full commit SHAs (with version comments) for supply-chain hardening, and add `.github/dependabot.yml` to keep the pinned actions up to date.

Follow-up to smkwlab/.github#69 (items 2/3/5).

## Pins applied (release.yml)

| Action | Pinned SHA | Tag |
|---|---|---|
| actions/checkout | 34e114876b0b11c390a56381ad16ebd13914f8d5 | v4.3.1 |
| erlef/setup-beam | 54075bcc5e249e4758d363f27d099f55d843f124 | v1.24.1 |
| actions/cache | 0057852bfaa89a56745cba8c7296529d2fc39830 | v4.3.0 |
| actions/upload-artifact | ea165f8d65b6e75b540449e92b4886f43607fa02 | v4.6.2 |
| actions/download-artifact | d3f86a106a0bac45b974a628896c90dbdf5c8093 | v4 |

## Notes

- Reusable `smkwlab/.github/.github/workflows/*.yml@v1` refs (elixir.yml, security.yml, ai-code-review.yml) are **intentionally left on `@v1`** — that is the org's shared-CI channel.
- `.github/dependabot.yml` added because Renovate in this repo is mix-only and does not manage GitHub Actions; Dependabot now updates the SHA-pinned actions weekly (grouped).
- Validated with `actionlint` (clean) and YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)