### PR TITLE
Sign release SHA256SUMS with cosign keyless

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,16 @@ jobs:
     name: Publish GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release and upload assets
+      id-token: write # keyless cosign signing via GitHub OIDC
 
     steps:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Download all build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -129,6 +135,21 @@ jobs:
           sha256sum "${bins[@]}" | tee SHA256SUMS
           # Sanity check the manifest round-trips before publishing.
           sha256sum -c SHA256SUMS
+
+      - name: Sign SHA256SUMS with cosign (keyless)
+        # Keyless signing via GitHub OIDC — no long-lived key. Produces a
+        # self-contained bundle (signature + Fulcio cert + Rekor proof) that
+        # ties the manifest to THIS release workflow's identity. Signing the
+        # manifest covers both binaries transitively (sha256sum -c does the rest).
+        run: |
+          cd release
+          cosign sign-blob --yes --bundle SHA256SUMS.cosign.bundle SHA256SUMS
+          # Fail the release if the bundle we just produced does not verify.
+          cosign verify-blob \
+            --bundle SHA256SUMS.cosign.bundle \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yml@refs/tags/" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            SHA256SUMS
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           # Fail the release if the bundle we just produced does not verify.
           cosign verify-blob \
             --bundle SHA256SUMS.cosign.bundle \
-            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yml@refs/tags/" \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/\.github/workflows/release\.yml@refs/tags/[^/]+$" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             SHA256SUMS
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,34 @@ grep tdig-macos-arm64 SHA256SUMS | shasum -a 256 -c -
 # tdig-macos-arm64: OK
 ```
 
+##### Verifying authenticity (cosign)
+
+The checksum above proves *integrity*. To also prove *authenticity* — that the
+manifest really came from tdig's release workflow and not someone who tampered
+with the release — each release's `SHA256SUMS` is signed with
+[cosign](https://github.com/sigstore/cosign) **keyless** signing (no
+maintainer-held key; the signature is bound to the release workflow's identity
+via GitHub OIDC and logged to the public Sigstore transparency log).
+
+This step is optional. If you have `cosign` installed and want the stronger
+guarantee, download the bundle alongside the manifest and verify:
+
+```bash
+curl -L -o SHA256SUMS https://github.com/smkwlab/tdig/releases/latest/download/SHA256SUMS
+curl -L -o SHA256SUMS.cosign.bundle https://github.com/smkwlab/tdig/releases/latest/download/SHA256SUMS.cosign.bundle
+
+cosign verify-blob \
+  --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/smkwlab/tdig/\.github/workflows/release\.yml@refs/tags/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+# Verified OK
+```
+
+Once the manifest is verified, the `sha256sum` check above ties the binaries to
+it. (`--certificate-identity-regexp` accepts any release tag; pin it to a
+specific tag like `…/release\.yml@refs/tags/0.4.1$` if you want to require one.)
+
 ### For Elixir developers — escript
 
 If you already have Elixir installed and want a fast iterative build:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ curl -L -o SHA256SUMS.cosign.bundle https://github.com/smkwlab/tdig/releases/lat
 
 cosign verify-blob \
   --bundle SHA256SUMS.cosign.bundle \
-  --certificate-identity-regexp '^https://github.com/smkwlab/tdig/\.github/workflows/release\.yml@refs/tags/' \
+  --certificate-identity-regexp '^https://github.com/smkwlab/tdig/\.github/workflows/release\.yml@refs/tags/[^/]+$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
 # Verified OK


### PR DESCRIPTION
## Summary

Follow-up to the E-5 checksums (smkwlab/.github#69): `SHA256SUMS` proves **integrity** but not **authenticity** — it sits on the same Release as the binaries, so an attacker who can tamper with the release can swap both. This adds **cosign keyless** signing to close that gap.

## Changes

**`release.yml`** (release job):
- `permissions: id-token: write` — keyless signing via GitHub OIDC (**no long-lived key/secret** to manage or rotate).
- Install `cosign` (`sigstore/cosign-installer`, SHA-pinned).
- Sign `SHA256SUMS` → `SHA256SUMS.cosign.bundle` (self-contained: signature + Fulcio cert + Rekor transparency-log proof), bound to this workflow's identity. Signing the manifest transitively covers both binaries.
- `verify-blob` the bundle **in-workflow** so a broken signature fails the release. Uploaded by the existing `release/*` glob.

**README** — optional "Verifying authenticity (cosign)" step:
```bash
cosign verify-blob \
  --bundle SHA256SUMS.cosign.bundle \
  --certificate-identity-regexp '^https://github.com/smkwlab/tdig/\.github/workflows/release\.yml@refs/tags/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  SHA256SUMS
```
Verification stays optional — the binary works without it; only verifiers pay the cost.

## Verification

- `actionlint` clean, YAML parses.
- ⚠️ Keyless signing needs the CI **OIDC token**, so it can only be exercised on a **real tagged release run** — it cannot be tested locally. The in-workflow `verify-blob` is the built-in self-check for that run. Recommend confirming on the next release (e.g. `0.4.1`) before relying on it.

Refs smkwlab/.github#69 (E-5 signing follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)