### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Tdig.MixProject do
   def project do
     [
       app: :tdig,
-      version: "0.4.0",
+      version: "0.4.1",
       name: "Tdig",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Prepare **0.4.1** — releases the cosign keyless signing added in #65. `mix.exs` `:version` `0.4.0` → `0.4.1`.

This release is also the end-to-end verification of the signing step: `release.yml` will sign `SHA256SUMS` → `SHA256SUMS.cosign.bundle` and `verify-blob` it in-CI, and the bundle will be attached to the GitHub Release.

## Verification
- `Mix.Project.config()[:version]` → `0.4.1` (the value the workflow's version guard checks)
- `mix test` passes (unchanged code; version-only bump)

After merge: `git tag 0.4.1 && git push origin 0.4.1` triggers the signed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)