### PR TITLE
Release 0.4.2: checkout v7, cache v6, cosign-installer v4 (cosign v3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Erlang/Elixir
         uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
@@ -52,7 +52,7 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
 
       - name: Cache mix dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.exs') }}
@@ -102,10 +102,10 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4
 
       - name: Download all build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ with the release — each release's `SHA256SUMS` is signed with
 maintainer-held key; the signature is bound to the release workflow's identity
 via GitHub OIDC and logged to the public Sigstore transparency log).
 
-This step is optional. If you have `cosign` installed and want the stronger
-guarantee, download the bundle alongside the manifest and verify:
+This step is optional. If you have **[cosign](https://github.com/sigstore/cosign) v3
+or newer** installed and want the stronger guarantee, download the bundle
+alongside the manifest and verify (releases from `0.4.2` on are signed with
+cosign v3, whose Sigstore-bundle format needs cosign v3+ to verify):
 
 ```bash
 curl -L -o SHA256SUMS https://github.com/smkwlab/tdig/releases/latest/download/SHA256SUMS

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Tdig.MixProject do
   def project do
     [
       app: :tdig,
-      version: "0.4.1",
+      version: "0.4.2",
       name: "Tdig",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Reviews Renovate #70 (cache v6) / #71 (checkout v7) / #72 (cosign-installer v4), all in the tag-triggered `release.yml`.

- **checkout v7 / cache v6**: safe — categorically stable, already validated on tenbin_dns #125.
- **cosign-installer v4 → cosign v3.0.6**: deliberate v2→v3 migration. Our `sign-blob`/`verify-blob` already use `--bundle` and `--certificate-identity-regexp`/`--certificate-oidc-issuer` (all valid in cosign v3, verified against the v3 docs). cosign v3's default bundle is the new Sigstore format → **downstream verification now needs cosign v3+**; README updated to state this.
- **mix.exs 0.4.1 → 0.4.2**: cuts a real release to validate cosign v3 signing end-to-end (the in-workflow `verify-blob` self-check runs at release time).

Supersedes #70 / #71 / #72. After merge: `git tag 0.4.2 && git push origin 0.4.2` triggers the signed release; I'll then verify the bundle + cosign v3 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)