### PR TITLE
ci: fix cosign-installer version annotation to real tag v4.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Download all build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4


### PR DESCRIPTION
## 概要

Dependency Dashboard (#69) の Renovate WARNING（`Could not determine new digest for update (github-tags package sigstore/cosign-installer)`）の修正。

## 原因と対応

- pin 注釈が `# v4` だったが、`sigstore/cosign-installer` に浮動タグ `v4` は存在しない（`git/ref/tags/v4` は 404）
- Renovate は注釈のタグ名から現行バージョンを解決するため、実在しないタグ名だと digest 更新の lookup に失敗する
- digest `6f9f177…` の実体は `v4.1.2`（tags API で確認済み）なので、注釈を `# v4.1.2` に修正

## 検証について

**コメントのみの変更**で、実行される workflow（digest 参照）は不変。release workflow の実走検証（実タグ）は不要で、Renovate 側の効果は次回実行時に dashboard #69 の WARNING が消えることで確認する。

Resolves #75

https://claude.ai/code/session_01A3UeXMSewEQ3dVRAKC95YR