### PR TITLE
fix: accept dig-style argument order and reject unknown types

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The command line syntax mirrors `dig`:
 tdig [options] [@server] host [type] [class]
 ```
 
-Positional arguments may appear in any order with respect to options; the leading `@` denotes the DNS server.
+Positional arguments may appear in any order, as in `dig`: a token matching a known record type or class name is interpreted as such regardless of position (so `tdig TXT example.com` and `tdig example.com TXT` are equivalent), and the leading `@` denotes the DNS server. To query a host literally named after a record type, add a trailing dot (e.g. `tdig txt.`).
 
 When unspecified:
 - **server** defaults to `8.8.8.8`

--- a/lib/tdig/cli.ex
+++ b/lib/tdig/cli.ex
@@ -92,12 +92,54 @@ defmodule Tdig.CLI do
   def parse_switches({parsed, argv, errors}),
     do: {Enum.map(parsed, &switch_convert_atom(&1)), argv, errors}
 
-  def switch_convert_atom({:class, value}), do: {:class, str2atom(value)}
-  def switch_convert_atom({:type, value}), do: {:type, str2atom(value)}
+  def switch_convert_atom({:class, value}) do
+    case parse_class(value) do
+      nil -> invalid_argument("Unknown class: #{value}")
+      class -> {:class, class}
+    end
+  end
+
+  def switch_convert_atom({:type, value}) do
+    case parse_type(value) do
+      nil -> invalid_argument("Unknown type: #{value}")
+      type -> {:type, type}
+    end
+  end
+
   def switch_convert_atom(n), do: n
 
-  @spec str2atom(String.t()) :: atom()
-  def str2atom(arg), do: arg |> String.downcase() |> String.to_atom()
+  # Known RR type/class names derived from tenbin_dns at compile time
+  # (classes are 16-bit, hence 0..0xFFFF). Runtime lookups are then pure
+  # map reads: arbitrary input never creates atoms, and no module-load
+  # order is assumed (escript loads modules lazily), see Issue #77.
+  @type_by_name for code <- 0..0xFFFF,
+                    type = DNS.type(code),
+                    into: %{},
+                    do: {Atom.to_string(type), type}
+
+  @class_by_name for code <- 0..0xFFFF,
+                     class = DNS.class(code),
+                     into: %{},
+                     do: {Atom.to_string(class), class}
+
+  @doc """
+  Converts a string to a known RR type atom, or returns `nil` so that
+  an invalid type never reaches packet creation (Issue #77).
+  """
+  @spec parse_type(String.t()) :: atom() | nil
+  def parse_type(arg), do: Map.get(@type_by_name, String.downcase(arg))
+
+  @doc """
+  Converts a string to a known DNS class atom, or returns `nil`.
+  """
+  @spec parse_class(String.t()) :: atom() | nil
+  def parse_class(arg), do: Map.get(@class_by_name, String.downcase(arg))
+
+  @spec invalid_argument(String.t()) :: no_return()
+  defp invalid_argument(message) do
+    IO.puts(:stderr, message)
+    System.halt(1)
+  end
 
   def parse_argv({parsed, argv, errors}) do
     {parsed, argv |> parse_argv_item(%{server: nil, name: nil, type: nil, class: nil}), errors}
@@ -115,21 +157,26 @@ defmodule Tdig.CLI do
     parse_argv_item(argv, %{result | server: arg1})
   end
 
-  def parse_argv_item([arg1 | argv], %{name: nil} = result) do
-    parse_argv_item(argv, %{result | name: arg1 |> add_tail_dot})
+  def parse_argv_item([arg1 | argv], result) do
+    parse_argv_item(argv, assign_positional_arg(arg1, result))
   end
 
-  def parse_argv_item([arg1 | argv], %{type: nil} = result) do
-    parse_argv_item(argv, %{result | type: arg1 |> str2atom})
-  end
+  # dig-compatible positional argument handling (Issue #77): a token that
+  # matches a known RR type (or class) name is taken as the type (or class)
+  # regardless of position, so both `tdig txt sony.com` and
+  # `tdig sony.com txt` work. Type wins over class for ambiguous tokens
+  # such as "any", and a trailing dot (e.g. "txt.") forces a token to be
+  # interpreted as a name, both as in dig.
+  defp assign_positional_arg(arg, result) do
+    type = if result.type == nil, do: parse_type(arg)
+    class = if result.class == nil, do: parse_class(arg)
 
-  def parse_argv_item([arg1 | argv], %{class: nil} = result) do
-    parse_argv_item(argv, %{result | class: arg1 |> str2atom})
-  end
-
-  def parse_argv_item(_, _) do
-    IO.puts(:stderr, "argument error")
-    System.halt(1)
+    cond do
+      type -> %{result | type: type}
+      class -> %{result | class: class}
+      result.name == nil -> %{result | name: add_tail_dot(arg)}
+      true -> invalid_argument("Invalid argument: #{arg}")
+    end
   end
 
   @spec add_tail_dot(String.t()) :: String.t()

--- a/test/tdig_test.exs
+++ b/test/tdig_test.exs
@@ -42,10 +42,73 @@ defmodule TdigTest do
       assert Tdig.a2s(:mx) == "MX"
     end
 
-    test "str2atom converts strings to lowercase atoms" do
-      assert Tdig.CLI.str2atom("A") == :a
-      assert Tdig.CLI.str2atom("CNAME") == :cname
-      assert Tdig.CLI.str2atom("mx") == :mx
+    test "parse_type converts known type names to lowercase atoms" do
+      assert Tdig.CLI.parse_type("A") == :a
+      assert Tdig.CLI.parse_type("CNAME") == :cname
+      assert Tdig.CLI.parse_type("mx") == :mx
+    end
+
+    test "parse_type returns nil for unknown type names" do
+      assert Tdig.CLI.parse_type("foo") == nil
+      assert Tdig.CLI.parse_type("sony.com") == nil
+      # a known atom that is not an RR type must not be accepted
+      assert Tdig.CLI.parse_type("help") == nil
+    end
+
+    test "parse_class converts known class names to lowercase atoms" do
+      assert Tdig.CLI.parse_class("IN") == :in
+      assert Tdig.CLI.parse_class("ch") == :ch
+    end
+
+    test "parse_class returns nil for unknown class names" do
+      assert Tdig.CLI.parse_class("foo") == nil
+      # RR type names are not classes
+      assert Tdig.CLI.parse_class("txt") == nil
+    end
+  end
+
+  describe "dig-compatible argument order (Issue #77)" do
+    test "parse_argv accepts type before name" do
+      assert Tdig.CLI.parse_argv({[], ["txt", "sony.com"], []}) ==
+               {[], %{name: "sony.com.", type: :txt, class: nil, server: nil}, []}
+    end
+
+    test "parse_argv accepts uppercase type before name" do
+      assert Tdig.CLI.parse_argv({[], ["TXT", "sony.com"], []}) ==
+               {[], %{name: "sony.com.", type: :txt, class: nil, server: nil}, []}
+    end
+
+    test "parse_argv accepts class and type in any position" do
+      assert Tdig.CLI.parse_argv({[], ["ch", "txt", "version.bind"], []}) ==
+               {[], %{name: "version.bind.", type: :txt, class: :ch, server: nil}, []}
+    end
+
+    test "parse_argv resolves any as type, not class" do
+      assert Tdig.CLI.parse_argv({[], ["any", "example.com"], []}) ==
+               {[], %{name: "example.com.", type: :any, class: nil, server: nil}, []}
+    end
+
+    test "parse_argv keeps name-first order working" do
+      assert Tdig.CLI.parse_argv({[], ["sony.com", "txt"], []}) ==
+               {[], %{name: "sony.com.", type: :txt, class: nil, server: nil}, []}
+    end
+
+    test "parse_argv with server, type and name in dig order" do
+      assert Tdig.CLI.parse_argv({[], ["@8.8.8.8", "txt", "sony.com"], []}) ==
+               {[], %{name: "sony.com.", type: :txt, class: nil, server: "8.8.8.8"}, []}
+    end
+
+    test "trailing dot forces a type-like token to be a name" do
+      # querying a host literally named "txt" is still possible, as in dig
+      assert Tdig.CLI.parse_argv({[], ["txt."], []}) ==
+               {[], %{name: "txt.", type: nil, class: nil, server: nil}, []}
+    end
+
+    test "unknown token becomes the name instead of an invalid type" do
+      # previously this token was force-converted to a type atom and
+      # crashed packet creation with ArgumentError (Issue #77)
+      assert Tdig.CLI.parse_argv({[], ["not-a-type"], []}) ==
+               {[], %{name: "not-a-type.", type: nil, class: nil, server: nil}, []}
     end
   end
 


### PR DESCRIPTION
Resolves #77

## 問題

`tdig txt sony.com` のようにクエリタイプを名前より先に指定すると、位置固定の引数解釈により `sony.com` が type として atom 化され、パケット生成時に `ArgumentError` でクラッシュしていた（詳細は #77）。

## 変更内容

### 1. dig 互換の位置引数解釈
- 位置引数のトークンが既知の RR type / class 名（case-insensitive）に一致する場合、位置に関係なく type / class として解釈する
- 曖昧なトークン（`any` は type と class の両方に存在）は dig 同様 **type 解釈を優先**
- 末尾ドット（`txt.`）で type 名と同名のホストを name として指定可能（dig と同じ escape hatch）
- name 設定済みで type/class にも該当しないトークンは `Invalid argument: <token>` で明示 exit（旧: 汎用の "argument error"）

### 2. 未知 type/class のエラーハンドリング
- `-t` / `-c` スイッチに未知の値を渡すと `Unknown type: foo` / `Unknown class: foo` を stderr に出して exit 1（旧: パケット生成まで進んで stacktrace 付きクラッシュ）

### 3. atom 安全性と escript 対応
- `str2atom`（`String.to_atom/1` による任意 atom 生成）を廃止
- 既知 type/class 名の逆引きマップを **コンパイル時に tenbin_dns から導出**（`DNS.type/1` / `DNS.class/1` を 0..0xFFFF で走査）。実行時は純粋な Map 参照のみ
  - 当初 `String.to_existing_atom/1` + membership 判定で実装したが、**escript は module を遅延ロードするため `DNS` 未ロード時に `:txt` 等の atom が存在せず誤判定**する問題を実機検証で発見し、この方式に変更（テストだけでは検出できないケース）

## 検証

TDD: 再現ケースを先にテスト化（9 件追加、実装前に red を確認）。

実機検証（escript 再ビルド後）:

| コマンド | 結果 |
|---|---|
| `./tdig txt sony.com` | ✅ `;sony.com. IN TXT`（旧: ArgumentError） |
| `./tdig TXT sony.com` | ✅ 同上 |
| `./tdig sony.com txt` | ✅ 従来どおり |
| `./tdig sony.com txt in` | ✅ class 併用 |
| `./tdig any example.com` | ✅ type ANY として解釈 |
| `./tdig txt.` | ✅ name `txt.` として解釈 |
| `./tdig -t foo sony.com` | ✅ `Unknown type: foo` / exit 1 |
| `./tdig -c foo sony.com` | ✅ `Unknown class: foo` / exit 1 |
| `./tdig sony.com badtype` | ✅ `Invalid argument: badtype` / exit 1 |
| `./tdig -x 8.8.8.8` / `--version` | ✅ 回帰なし |

品質: `mix test`（55 passed）/ `mix credo --strict`（no issues）/ `mix format --check-formatted` すべて green。

README の Usage 節も順不同解釈に合わせて更新。